### PR TITLE
Release v0.1.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,5 +54,21 @@ jobs:
       - name: Publish
         if: steps.check.outputs.changed == 'true'
         run: npm publish --access public
+  github-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: publish
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check if version has been updated
+        id: check
+        uses: EndBug/version-check@v2
+      - name: Tag
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git tag `cat package.json | jq -r '.version'`
+          git push origin --tags
       - name: Release
+        if: steps.check.outputs.changed == 'true'
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ TODO: finish this
 
 ## Changelog
 
+
+### Version 0.1.2
+- minor: improving returned types by flattening them = better TS inspection
+- exposing two new helper types: `OmnibusEvents` and `OmnibusEventPayload`
+- Fixed issue with Registrator's `.off` method not working properly
+- Added support for disposing `OmnibusRegistrator` and added documentation around this logic
+
 ### Version 0.1.1
 - Fixing issue with `.reduce` interface - now handles arrays properly
 - Adding `.memoize` builder method so values can be properly handled between calls

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,8 @@ export default defineConfig({
               { text: 'Installation', link: '/installation' },
               { text: 'Registering Events', link: '/registering-events' },
               { text: 'Triggering Events', link: '/triggering-events' },
-              { text: 'Listening to Events', link: '/listening-to-events' }
+              { text: 'Listening to Events', link: '/listening-to-events' },
+              { text: 'Using Registrator', link: '/using-registrator' }
             ]
           },
           {

--- a/docs/using-registrator.md
+++ b/docs/using-registrator.md
@@ -1,0 +1,53 @@
+# Using registrator
+
+When providing public event API you might want to expose ability to listen to events but not allow external parties to trigger them. To support this use case, Omnibus provides ability generate registrators.
+
+Registrator is an object that exposes methods to listen to events: `.on`, `.off` and `.offAll`.
+
+
+::: info
+
+When multiple registrators are created for the same event bus, their callbacks are independent: calling `.offAll` on one registrator will not unregister callbacks from the other registrator nor the ones registered on the main bus.
+
+:::
+
+## Creating registrator
+
+To create registrator, call `.getRegistrator()` method on your `Omnibus` event bus:
+```ts
+import { Omnibus, args } from '@hypersphere/omnibus';
+
+const bus = Omnibus.builder()
+.register('log', args<string>())
+.build()
+
+const reg = bus.getRegistrator()
+
+const cb = jest.fn()
+
+reg.on('log', cb)
+
+bus.trigger('log', 'hello')
+```
+
+
+## Disposing registrator
+
+To make sure all your callbacks have been disposed after registrator is no longer needed, you can use `using` keyword.
+
+::: info
+You need to use TypeScript 5.2+ to use this feature and enable ES2022 and `esnext.disposable` lib in your tsconfig.
+:::
+
+```ts
+const bus = Omnibus.builder()
+    .register('log', args<string>())
+    .build()
+const cb = jest.fn()
+{
+    using reg = bus.getRegistrator()
+    reg.on('log', cb)
+    bus.trigger('log', 'hello')
+}
+bus.trigger('log', 'hello 2') // This will not trigger any callback
+```

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "devDependencies": {
-    "@babel/plugin-proposal-explicit-resource-management": "^7.23.3",
-    "@babel/preset-env": "^7.23.8",
+    "@babel/plugin-proposal-explicit-resource-management": "^7.23.9",
+    "@babel/preset-env": "^7.23.9",
     "@babel/preset-typescript": "^7.23.3",
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
     "prettier": "3.2.4",
     "typescript": "5.3.3",
-    "vitepress": "^1.0.0-rc.39",
-    "vitepress-plugin-twoslash": "^0.10.0-beta.9"
+    "vitepress": "^1.0.0-rc.40",
+    "vitepress-plugin-twoslash": "^0.10.2"
   },
   "scripts": {
     "compile": "tsc",
@@ -23,6 +23,6 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
-    "@hypersphere/omnibus": "^0.1.0"
+    "@hypersphere/omnibus": "^0.1.1"
   }
 }

--- a/src/BusBuilder.test.ts
+++ b/src/BusBuilder.test.ts
@@ -59,6 +59,5 @@ describe("Bus Builder", () => {
 
         expect(onError).not.toHaveBeenCalled()
         expect(onWarning).toHaveBeenCalled()
-
     })
 })

--- a/src/BusBuilder.ts
+++ b/src/BusBuilder.ts
@@ -2,10 +2,12 @@ import { BuildableBuilder, Builder } from "./Builder";
 import { Omnibus } from "./Omnibus";
 import { Definitions, Transformers, Parameters } from "./types";
 
+type FlatType<T> = T extends object ? { [K in keyof T]: FlatType<T[K]> } : T
+
 export class BusBuilder<D extends Definitions = {}> {
     #transformers: Transformers<D> = new Map()
     register<N extends string, T>(name: N, _: Builder<Parameters<T>>) {
-        return this as unknown as BusBuilder<D & Record<N, Parameters<T>>>
+        return this as unknown as BusBuilder<FlatType<D & Record<N, Parameters<T>>>>
     }
 
     derive<T extends string, Der extends keyof D, Inp, Res extends Parameters<any>>(targetKey: T, sourceKey: Der, fn: (b: Builder<D[Der], D[Der]>) => Builder<D[Der], Res>) {
@@ -20,11 +22,11 @@ export class BusBuilder<D extends Definitions = {}> {
                 transformer,
             }
         ])
-        return this as unknown as BusBuilder<D & Record<T, Parameters<Res>>>
+        return this as unknown as BusBuilder<FlatType<D & Record<T, Parameters<Res>>>>
     }
 
     build() {
-        const bus = new Omnibus<D>(this.#transformers)
+        const bus = new Omnibus<FlatType<D>>(this.#transformers)
 
         return bus
     }

--- a/src/Omnibus.ts
+++ b/src/Omnibus.ts
@@ -3,6 +3,7 @@ import { OmnibusRegistrator } from "./Registrator";
 import { CallbackType, Definitions, Transformers, UnregisterCallback } from "./types";
 import { BusBuilder } from "./BusBuilder";
 
+
 export class Omnibus<EventDefinitions extends Record<keyof EventDefinitions, unknown[]> = Record<string, unknown[]>> {
     #callbacks: Map<keyof EventDefinitions, Array<CallbackType<EventDefinitions[keyof EventDefinitions]>>>;
     #transformers: Transformers<EventDefinitions>
@@ -56,3 +57,7 @@ export class Omnibus<EventDefinitions extends Record<keyof EventDefinitions, unk
         return new OmnibusRegistrator(this);
     }
 }
+
+export type OmnibusEvents<O extends Omnibus<any>> = O extends Omnibus<infer E> ? E : never
+
+export type OmnibusEventPayload<O extends Omnibus<any>, K extends keyof OmnibusEvents<O>> = OmnibusEvents<O>[K]

--- a/src/Registrator.test.ts
+++ b/src/Registrator.test.ts
@@ -1,0 +1,89 @@
+import { args } from "./Builder"
+import { Omnibus } from "./Omnibus"
+
+describe("Test registrator", () => {
+	it("should properly create registrator that listens to main bus", async () => {
+		const bus = Omnibus.builder()
+			.register('log', args<string>())
+			.build()
+
+		const registrator = bus.getRegistrator()
+
+		const callback = jest.fn()
+		registrator.on('log', callback)
+
+		bus.trigger('log', 'test 1')
+		expect(callback).toHaveBeenCalledWith('test 1')
+	})
+
+	it('should properly create two independent registrators', async () => {
+		const bus = Omnibus.builder()
+			.register('log', args<string>())
+			.build()
+
+		const registrator1 = bus.getRegistrator()
+
+		const callback = jest.fn()
+		registrator1.on('log', callback)
+
+		const registrator2 = bus.getRegistrator()
+		registrator2.on('log', callback)
+
+		bus.trigger('log', 'test 1')
+		expect(callback).toHaveBeenCalledWith('test 1')
+		expect(callback).toHaveBeenCalledTimes(2)
+
+		registrator1.off('log', callback)
+
+		bus.trigger('log', 'test 2')
+
+		expect(callback).toHaveBeenCalledWith('test 2')
+		expect(callback).toHaveBeenCalledTimes(3)
+	})
+
+	it('should properly offAll evets', async () => {
+		const bus = Omnibus.builder()
+			.register('log', args<string>())
+			.build()
+
+			const reg = bus.getRegistrator()
+
+			const cb1 = jest.fn()
+			const cb2 = jest.fn()
+
+			reg.on('log', cb1)
+			reg.on('log', cb2)
+
+
+			bus.trigger('log', 'trig 1')
+			expect(cb1).toHaveBeenCalledTimes(1)
+			expect(cb2).toHaveBeenCalledTimes(1)
+
+			cb1.mockClear()
+			cb2.mockClear()
+			
+			reg.offAll()
+			bus.trigger('log', 'hello world 2')
+
+			expect(cb1).not.toHaveBeenCalled()
+			expect(cb2).not.toHaveBeenCalled()
+	})
+
+	it('should properly dispose registartor', async () => {
+		const bus = Omnibus.builder()
+			.register('log', args<string>())
+			.build()
+		const cb = jest.fn()
+		{
+			using reg = bus.getRegistrator()
+			reg.on('log', cb)
+			bus.trigger('log', 'hello')
+			expect(cb).toHaveBeenCalledWith('hello')
+			expect(cb).toHaveBeenCalledTimes(1)
+		}
+		bus.trigger('log', 'hello 2')
+		expect(cb).toHaveBeenCalledTimes(1)
+		expect(cb).not.toHaveBeenCalledWith('hello 2')
+	})
+
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
-import { Omnibus } from "./Omnibus";
+import { Omnibus, type OmnibusEvents, type OmnibusEventPayload } from "./Omnibus";
 import { OmnibusRegistrator } from "./Registrator";
 import { CallbackType, UnregisterCallback } from "./types";
 import { BusBuilder } from './BusBuilder';
 import { args } from "./Builder";
 
-export { Omnibus, OmnibusRegistrator, CallbackType, UnregisterCallback, BusBuilder, args };
+export {
+    Omnibus,
+    OmnibusRegistrator,
+    CallbackType,
+    UnregisterCallback,
+    BusBuilder,
+    args,
+    OmnibusEvents,
+    OmnibusEventPayload
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,3 @@ export interface Transform<D extends Definitions> {
     transformer: (t: Trigger, ...d: any) => Promise<void>;
 }
 export type Transformers<D extends Definitions> = Map<keyof D, undefined | Transform<D>[]>;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,17 +234,6 @@
     regexpu-core "^5.3.1"
     semver "^6.3.1"
 
-"@babel/helper-define-polyfill-provider@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz#64df615451cb30e94b59a9696022cffac9a10088"
-  integrity sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==
-  dependencies:
-    "@babel/helper-compilation-targets" "^7.22.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    debug "^4.1.1"
-    lodash.debounce "^4.0.8"
-    resolve "^1.14.2"
-
 "@babel/helper-define-polyfill-provider@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz#465805b7361f461e86c680f1de21eaf88c25901b"
@@ -423,10 +412,10 @@
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-proposal-explicit-resource-management@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-explicit-resource-management/-/plugin-proposal-explicit-resource-management-7.23.3.tgz#08485b8b7a7b43f1fead530c60c92eb58c4dd861"
-  integrity sha512-f1FebOc7H/JZ4CBbj6dtdpJ0mj23HuEK0UnYJ6Jv+vqAVfHIj8Nxq/rCdyIL+52TKlQGDuh2cCoTIaV/4nYEmQ==
+"@babel/plugin-proposal-explicit-resource-management@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-explicit-resource-management/-/plugin-proposal-explicit-resource-management-7.23.9.tgz#5c1dce32644016b03e603b3d5cdab57028f36f93"
+  integrity sha512-D0mkTJZ3p2+yS282sFRQvH+L1uHJt+LD2RdkQoGIFknyTUbqzUnrX1OEDPzMIOuoED4XnLcn+2W2uAoHdcRhBw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-explicit-resource-management" "^7.23.3"
@@ -598,10 +587,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-async-generator-functions@^7.23.7":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz#3aa0b4f2fa3788b5226ef9346cf6d16ec61f99cd"
-  integrity sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==
+"@babel/plugin-transform-async-generator-functions@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz#9adaeb66fc9634a586c5df139c6240d41ed801ce"
+  integrity sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==
   dependencies:
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-plugin-utils" "^7.22.5"
@@ -780,10 +769,10 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/helper-simple-access" "^7.22.5"
 
-"@babel/plugin-transform-modules-systemjs@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz#fa7e62248931cb15b9404f8052581c302dd9de81"
-  integrity sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==
+"@babel/plugin-transform-modules-systemjs@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz#105d3ed46e4a21d257f83a2f9e2ee4203ceda6be"
+  integrity sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==
   dependencies:
     "@babel/helper-hoist-variables" "^7.22.5"
     "@babel/helper-module-transforms" "^7.23.3"
@@ -989,10 +978,10 @@
     "@babel/helper-create-regexp-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/preset-env@^7.23.8":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.8.tgz#7d6f8171ea7c221ecd28059e65ad37c20e441e3e"
-  integrity sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==
+"@babel/preset-env@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.9.tgz#beace3b7994560ed6bf78e4ae2073dff45387669"
+  integrity sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==
   dependencies:
     "@babel/compat-data" "^7.23.5"
     "@babel/helper-compilation-targets" "^7.23.6"
@@ -1021,7 +1010,7 @@
     "@babel/plugin-syntax-top-level-await" "^7.14.5"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
     "@babel/plugin-transform-arrow-functions" "^7.23.3"
-    "@babel/plugin-transform-async-generator-functions" "^7.23.7"
+    "@babel/plugin-transform-async-generator-functions" "^7.23.9"
     "@babel/plugin-transform-async-to-generator" "^7.23.3"
     "@babel/plugin-transform-block-scoped-functions" "^7.23.3"
     "@babel/plugin-transform-block-scoping" "^7.23.4"
@@ -1043,7 +1032,7 @@
     "@babel/plugin-transform-member-expression-literals" "^7.23.3"
     "@babel/plugin-transform-modules-amd" "^7.23.3"
     "@babel/plugin-transform-modules-commonjs" "^7.23.3"
-    "@babel/plugin-transform-modules-systemjs" "^7.23.3"
+    "@babel/plugin-transform-modules-systemjs" "^7.23.9"
     "@babel/plugin-transform-modules-umd" "^7.23.3"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.22.5"
     "@babel/plugin-transform-new-target" "^7.23.3"
@@ -1069,9 +1058,9 @@
     "@babel/plugin-transform-unicode-regex" "^7.23.3"
     "@babel/plugin-transform-unicode-sets-regex" "^7.23.3"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
-    babel-plugin-polyfill-corejs2 "^0.4.7"
-    babel-plugin-polyfill-corejs3 "^0.8.7"
-    babel-plugin-polyfill-regenerator "^0.5.4"
+    babel-plugin-polyfill-corejs2 "^0.4.8"
+    babel-plugin-polyfill-corejs3 "^0.9.0"
+    babel-plugin-polyfill-regenerator "^0.5.5"
     core-js-compat "^3.31.0"
     semver "^6.3.1"
 
@@ -1307,6 +1296,13 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@hypersphere/omnibus/-/omnibus-0.1.0.tgz#411efddf2d2fd28e1e35ab4cfb5f354b44d78c40"
   integrity sha512-mnSe9cJhSUTUx1UAQVZPBE2RfhSFhjjAmMZiB4KCvugt+tKvM5G7Y85ti3kXz5BSS1QVj99hZhLwKT03KUUerQ==
+
+"@hypersphere/omnibus@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@hypersphere/omnibus/-/omnibus-0.1.1.tgz#bc073af1abfd491dd95dc0ca801477bede058d07"
+  integrity sha512-5MUX9qGd0sYPo/jL9whC6OIAjZS1viZjEv+EAVvJekWrZoAq64dOnMBGUUdjiC7QaYl+1W4cJxC7BMvGfO/tAA==
+  dependencies:
+    "@hypersphere/omnibus" "^0.1.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2043,7 +2039,7 @@ babel-plugin-jest-hoist@^29.6.3:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-polyfill-corejs2@^0.4.7:
+babel-plugin-polyfill-corejs2@^0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz#dbcc3c8ca758a290d47c3c6a490d59429b0d2269"
   integrity sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==
@@ -2052,15 +2048,15 @@ babel-plugin-polyfill-corejs2@^0.4.7:
     "@babel/helper-define-polyfill-provider" "^0.5.0"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz#941855aa7fdaac06ed24c730a93450d2b2b76d04"
-  integrity sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==
+babel-plugin-polyfill-corejs3@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz#9eea32349d94556c2ad3ab9b82ebb27d4bf04a81"
+  integrity sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.4.4"
-    core-js-compat "^3.33.1"
+    "@babel/helper-define-polyfill-provider" "^0.5.0"
+    core-js-compat "^3.34.0"
 
-babel-plugin-polyfill-regenerator@^0.5.4:
+babel-plugin-polyfill-regenerator@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz#8b0c8fc6434239e5d7b8a9d1f832bb2b0310f06a"
   integrity sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==
@@ -2262,7 +2258,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-core-js-compat@^3.31.0, core-js-compat@^3.33.1:
+core-js-compat@^3.31.0, core-js-compat@^3.34.0:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.35.1.tgz#215247d7edb9e830efa4218ff719beb2803555e2"
   integrity sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==
@@ -3857,44 +3853,32 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shikiji-core@0.10.0-beta.9:
-  version "0.10.0-beta.9"
-  resolved "https://registry.yarnpkg.com/shikiji-core/-/shikiji-core-0.10.0-beta.9.tgz#4fcc2c726347cb93a2a6ad36744fcabf1a45f91e"
-  integrity sha512-7dgwTyN9PeKyc4KJeyKo/qW8gi8XbR//c1CO+0B5GaeozWexNTpEL/tSohyIKkj0Z+7spfm2REmAaS39NlC4Lw==
+shikiji-core@0.10.2, shikiji-core@^0.10.0:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/shikiji-core/-/shikiji-core-0.10.2.tgz#19c5cba664c12a80e726bd627a0e08313a67bd5f"
+  integrity sha512-9Of8HMlF96usXJHmCL3Gd0Fcf0EcyJUF9m8EoAKKd98mHXi0La2AZl1h6PegSFGtiYcBDK/fLuKbDa1l16r1fA==
 
-shikiji-core@0.9.19, shikiji-core@^0.9.19:
-  version "0.9.19"
-  resolved "https://registry.yarnpkg.com/shikiji-core/-/shikiji-core-0.9.19.tgz#227975e998eb2a579cf83de30977762be3802507"
-  integrity sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==
-
-shikiji-transformers@^0.9.19:
-  version "0.9.19"
-  resolved "https://registry.yarnpkg.com/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz#23e629804d5f20332712f44f3907c03ce39052af"
-  integrity sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==
+shikiji-transformers@^0.10.0:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/shikiji-transformers/-/shikiji-transformers-0.10.2.tgz#fda6551a53b32b7e1a3b16917eddb0836ae47f87"
+  integrity sha512-7IVTwl1af205ywYEq5bOAYOTOFW4V1dVX1EablP0nWKErqZeD1o93VMytxmtJomqS+YwbB8doY8SE3MFMn0aPQ==
   dependencies:
-    shikiji "0.9.19"
+    shikiji "0.10.2"
 
-shikiji-twoslash@0.10.0-beta.9:
-  version "0.10.0-beta.9"
-  resolved "https://registry.yarnpkg.com/shikiji-twoslash/-/shikiji-twoslash-0.10.0-beta.9.tgz#908442a3c28e3a500ca14f44f470e869db4c73ed"
-  integrity sha512-VZNysft2sky0I5p4xCwoJ4BN1VxtRrY+aBu20hYGbX5IetUZl0jDFtdpNC32GUUhOddx/gy0X/fSCoomv0FE2Q==
+shikiji-twoslash@0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/shikiji-twoslash/-/shikiji-twoslash-0.10.2.tgz#ee8ff40f9ad79d923b8dcc9f77d5317f6fb76097"
+  integrity sha512-BeIo3TsuWMh07dn0RjPvmAxJh6zeZu0kbPW1m6R0kvKOgh/jSa9+Mu75evHfPabNJumtMELT5osnzlv66x87wg==
   dependencies:
-    shikiji-core "0.10.0-beta.9"
-    twoslash "^0.0.11"
+    shikiji-core "0.10.2"
+    twoslash "^0.1.0"
 
-shikiji@0.10.0-beta.9:
-  version "0.10.0-beta.9"
-  resolved "https://registry.yarnpkg.com/shikiji/-/shikiji-0.10.0-beta.9.tgz#05e1ca5711b528cf07ec60dad4060d8ad5f16b86"
-  integrity sha512-I+sv642n9M7/FK/dVcXp9vMv7v5Wa8gU2UuKwkIWKQFvyo+qKB8eV1zNNtRYas+jC7BLwdAaflc5BFUozAonFQ==
+shikiji@0.10.2, shikiji@^0.10.0:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/shikiji/-/shikiji-0.10.2.tgz#178391422225c50c0499f4d841baaa9568a79769"
+  integrity sha512-wtZg3T0vtYV2PnqusWQs3mDaJBdCPWxFDrBM/SE5LfrX92gjUvfEMlc+vJnoKY6Z/S44OWaCRzNIsdBRWcTAiw==
   dependencies:
-    shikiji-core "0.10.0-beta.9"
-
-shikiji@0.9.19, shikiji@^0.9.19:
-  version "0.9.19"
-  resolved "https://registry.yarnpkg.com/shikiji/-/shikiji-0.9.19.tgz#351a32b291a04cf9a6b69933f8044fe135b70f6f"
-  integrity sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==
-  dependencies:
-    shikiji-core "0.9.19"
+    shikiji-core "0.10.2"
 
 signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -4042,18 +4026,18 @@ trim-lines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
-twoslash-vue@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/twoslash-vue/-/twoslash-vue-0.0.11.tgz#e0c66715e399447b900ce417f13762c1357ab81c"
-  integrity sha512-Si6k4pprpizqbuvxRHQWegIpBHGmoSf4FqHlUYxsSYddCDdaRsgt2OYq6rbmp3L6sZA26TYOuY0nHXBODU+kjw==
+twoslash-vue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/twoslash-vue/-/twoslash-vue-0.1.0.tgz#799be5308dbf9a6391387221618f8f558c8bae93"
+  integrity sha512-4IVOdvQcjLY5KTrsR9GuTUAThhpYQqkkKawCtfUaTSkui3CXR2KPYBJMvY5yM1by+TkENBlW1ykLywP2BGukHg==
   dependencies:
     "@vue/language-core" "^1.8.27"
-    twoslash "0.0.11"
+    twoslash "0.1.0"
 
-twoslash@0.0.11, twoslash@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/twoslash/-/twoslash-0.0.11.tgz#68956b5c343f532fcc7305cbcc5d37c7dcac1c35"
-  integrity sha512-XCxpr8Of+swV66Ox5aTqkozax6tFjJrfP0UZrGNaKlqHDyvY1gUNZE2lUqj9phyF4cKoo/LxzOhkQw7zBmRyVw==
+twoslash@0.1.0, twoslash@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/twoslash/-/twoslash-0.1.0.tgz#4508ca2450f42905e3f7c4a6d970798108e238d8"
+  integrity sha512-zvDn23/FwNdi/i2xMTTDcn7xnX4iKlp6tJt68aD86zRqesQrb/HOnMBtaUu6+vme4gtlX9ScEfKYog1+7IPKSw==
   dependencies:
     "@typescript/vfs" "1.5.0"
 
@@ -4172,7 +4156,7 @@ vfile@^6.0.0:
     unist-util-stringify-position "^4.0.0"
     vfile-message "^4.0.0"
 
-vite@^5.0.11:
+vite@^5.0.12:
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.12.tgz#8a2ffd4da36c132aec4adafe05d7adde38333c47"
   integrity sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==
@@ -4183,24 +4167,24 @@ vite@^5.0.11:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitepress-plugin-twoslash@^0.10.0-beta.9:
-  version "0.10.0-beta.9"
-  resolved "https://registry.yarnpkg.com/vitepress-plugin-twoslash/-/vitepress-plugin-twoslash-0.10.0-beta.9.tgz#322a545065ddf9edb390eda18ec63ca272e6843b"
-  integrity sha512-2KaE8QRaXQCR0KD4TChqwRAOEeax5QCTiMiM/h/uCCQKRcXzevSPackkcz5Rwwxv1djXhL6hJCU2n2cg4OZ8dg==
+vitepress-plugin-twoslash@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/vitepress-plugin-twoslash/-/vitepress-plugin-twoslash-0.10.2.tgz#8801dd5b0724d41964caf9b3dac1a07b25b2e33b"
+  integrity sha512-4Ydecs+aZJkIu/QmTTJNqYmBE6taRU4NTx/CQq7fbWex0mFqbplSwfFmyI/wmZtcGtGYE8xmk/jGqORVBmi0Nw==
   dependencies:
     floating-vue "^5.2.0"
     mdast-util-from-markdown "^2.0.0"
     mdast-util-gfm "^3.0.0"
     mdast-util-to-hast "^13.1.0"
-    shikiji "0.10.0-beta.9"
-    shikiji-twoslash "0.10.0-beta.9"
-    twoslash-vue "^0.0.11"
-    vue "^3.4.14"
+    shikiji "0.10.2"
+    shikiji-twoslash "0.10.2"
+    twoslash-vue "^0.1.0"
+    vue "^3.4.15"
 
-vitepress@^1.0.0-rc.39:
-  version "1.0.0-rc.39"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-rc.39.tgz#80f19dafde8d73d97024a4149b63ea2a41c8a59d"
-  integrity sha512-EcgoRlAAp37WOxUOYv45oxyhLrcy3Upey+mKpqW3ldsg6Ol4trPndRBk2GO0QiSvEKlb9BMerk49D/bFICN6kg==
+vitepress@^1.0.0-rc.40:
+  version "1.0.0-rc.40"
+  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-rc.40.tgz#ad63f04c5296fc20daf32a4edd46677e95398eca"
+  integrity sha512-1x9PCrcsJwqhpccyTR93uD6jpiPDeRC98CBCAQLLBb44a3VSXYBPzhCahi+2kwAYylu49p0XhseMPVM4IVcWcw==
   dependencies:
     "@docsearch/css" "^3.5.2"
     "@docsearch/js" "^3.5.2"
@@ -4212,11 +4196,11 @@ vitepress@^1.0.0-rc.39:
     focus-trap "^7.5.4"
     mark.js "8.11.1"
     minisearch "^6.3.0"
-    shikiji "^0.9.19"
-    shikiji-core "^0.9.19"
-    shikiji-transformers "^0.9.19"
-    vite "^5.0.11"
-    vue "^3.4.14"
+    shikiji "^0.10.0"
+    shikiji-core "^0.10.0"
+    shikiji-transformers "^0.10.0"
+    vite "^5.0.12"
+    vue "^3.4.15"
 
 vue-demi@>=0.14.6:
   version "0.14.6"
@@ -4236,7 +4220,7 @@ vue-template-compiler@^2.7.14:
     de-indent "^1.0.2"
     he "^1.2.0"
 
-vue@^3.4.14:
+vue@^3.4.15:
   version "3.4.15"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.4.15.tgz#91f979844ffca9239dff622ba4c79c5d5524b88c"
   integrity sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==


### PR DESCRIPTION
- minor: improving returned types by flattening them = better TS inspection
- exposing two new helper types: `OmnibusEvents` and `OmnibusEventPayload`
- Fixed issue with Registrator's `.off` method not working properly
- Added support for disposing `OmnibusRegistrator` and added documentation around this logic