### PR TITLE
release: Adding new `.from` method.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
     permissions:
       contents: write
     needs: publish
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v1
       - name: Check if version has been updated

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ TODO: finish this
 ## Changelog
 
 
+### Version 0.1.3
+- Added new `.from` method for `Omnibus.builder()` - you can now combine events from other buses (including native buses and other libraries!)
+
 ### Version 0.1.2
 - minor: improving returned types by flattening them = better TS inspection
 - exposing two new helper types: `OmnibusEvents` and `OmnibusEventPayload`

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,7 +26,9 @@ export default defineConfig({
               { text: 'Registering Events', link: '/registering-events' },
               { text: 'Triggering Events', link: '/triggering-events' },
               { text: 'Listening to Events', link: '/listening-to-events' },
-              { text: 'Using Registrator', link: '/using-registrator' }
+              { text: 'Using Registrator', link: '/using-registrator' },
+              { text: 'Creating Events from Other Buses', link: '/creating-events-from-other-buses' }
+
             ]
           },
           {

--- a/docs/creating-events-from-other-buses.md
+++ b/docs/creating-events-from-other-buses.md
@@ -1,0 +1,39 @@
+# Creating events from other buses
+
+You can register an event in your bus that comes from another bus. It can be either:
+- Anoter Omnibus bus
+- HTML Event Listener
+- Any other class / object / library that allows to register events using `.addEventListener` method
+- Any other class / object / library that allows to register events using `.on` method
+- Any other class / object / library that allow to register events using declaration of `.on{eventName}` function.
+
+::: warning
+This is experimental feature and there is no way of unsbscribing from the target at the moment. You can call `.offAll` and no events will be triggered but Omnibus is not able to fully clean up after itself and there will be still empty event registered in the target bus. This issue will be addressed in the future release.
+
+:::
+
+```ts
+import { Omnibus, args } from '@hypersphere/omnibus'
+
+const bus = Omnibus.builder()
+.register('log', args<string>())
+.build()
+
+const bus2 = Omnibus.builder()
+.from(bus, 'log', 'logOnAnotherBus')
+.build()
+
+bus2.on('logOnAnotherBus', (data) => console.log(data))
+
+bus1.trigger('log', 'hello world')
+```
+
+You can pass either bus or registrator function itself:
+
+```ts
+Omnibus.builder()
+.from(bus, 'log', 'newLogName') // This works
+.from(bus.on, 'log', 'log2') // This works too
+```
+
+If you omit new name of the event, the original name will be used instead.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypersphere/omnibus",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/BusBuilder.ts
+++ b/src/BusBuilder.ts
@@ -4,10 +4,65 @@ import { Definitions, Transformers, Parameters } from "./types";
 
 type FlatType<T> = T extends object ? { [K in keyof T]: FlatType<T[K]> } : T
 
-export class BusBuilder<D extends Definitions = {}> {
+
+type CallbackRegistrator<T extends string, P extends Array<any>> = (key: T, cb: (...x: P) => any) => any
+
+type OldschoolOnRegistrator<T extends string, P extends Array<any>> = Record<`on${T}`, (...val: P) => void>
+
+type AddEventListenerRegistrator<T extends string, P extends Array<any>> = { 
+    addEventListener: (k: T, cb: (...v: P) => any) => any
+}
+
+
+type OnRegistrator<T, P extends Array<any>> = {
+    on: (k: T, cb: (...v: P) => any) => any
+}
+
+type FromType<T extends string, P extends Array<any>> = CallbackRegistrator<T, P> | OldschoolOnRegistrator<T, P> | AddEventListenerRegistrator<T, P> | Omnibus<any> | OnRegistrator<T, P>
+
+export type TypeKeys<T> = T extends OldschoolOnRegistrator<any, any>
+    ? RemoveOn<keyof T & `on${string}`>
+    : T extends Omnibus<infer B>
+        ? keyof B
+        : T extends FromType<infer K, any>
+            ? K
+            : never
+
+export type CallbackType<T extends FromType<K, any>, K extends string> = T extends Omnibus<infer X>
+    ? K extends keyof X
+        ? X[K]
+        : never
+    : T extends OldschoolOnRegistrator<K, infer P>
+        ? P 
+        : T extends FromType<K, infer P>
+            ? P
+            : never
+
+type RemoveOn<T> = T extends `on${infer P}` ? P : never
+
+type SecondIfUndefned<T, J> = Exclude<T, undefined> extends never ? J : T
+
+const isOldschoolOnRegistrator = <T extends string, P extends Array<any>>(b: FromType<T, P>, e: string): b is OldschoolOnRegistrator<T, P> => {
+    return !!b[`on${e}`] && typeof b[`on${e}`] === 'function'
+}
+
+const isEventListenerRegistrator = <T extends string, P extends Array<any>>(b: FromType<T, P>): b is AddEventListenerRegistrator<T, P> => {
+    return !!b['addEventListener'] && typeof b['addEventListener'] === 'function'
+}
+
+const isCallbackRegistrator = <T extends string, P extends Array<any>>(b: FromType<T, P>): b is CallbackRegistrator<T, P> => {
+    return typeof b === 'function'
+}
+
+const isOmnibusRegistrator = <T extends string, P extends Array<any>>(b: FromType<T, P>): b is Omnibus<any, any> => {
+    return !!b['on'] && typeof b['on'] === 'function'
+}
+
+
+export class BusBuilder<D extends Definitions = {}, OmitKeys extends string = ''> {
     #transformers: Transformers<D> = new Map()
     register<N extends string, T>(name: N, _: Builder<Parameters<T>>) {
-        return this as unknown as BusBuilder<FlatType<D & Record<N, Parameters<T>>>>
+        return this as unknown as BusBuilder<FlatType<D & Record<N, Parameters<T>>>, OmitKeys>
     }
 
     derive<T extends string, Der extends keyof D, Inp, Res extends Parameters<any>>(targetKey: T, sourceKey: Der, fn: (b: Builder<D[Der], D[Der]>) => Builder<D[Der], Res>) {
@@ -22,11 +77,53 @@ export class BusBuilder<D extends Definitions = {}> {
                 transformer,
             }
         ])
-        return this as unknown as BusBuilder<FlatType<D & Record<T, Parameters<Res>>>>
+        return this as unknown as BusBuilder<FlatType<D & Record<T, Parameters<Res>>>, OmitKeys>
+    }
+
+
+    #registers: ((b: Omnibus) => void)[] = []
+    from<const T extends string, Ret extends FromType<T, any>, const K extends string>(bus: Ret, event: TypeKeys<Ret>, newEvent?: K) {
+
+        const register = (omnibus: Omnibus) => {
+            console.log('regis', register)
+            // return
+            if (isEventListenerRegistrator(bus)) {
+                // FIXME: add unregister somewhere.
+                const cb = (...v) => {
+                    omnibus.trigger(newEvent || event, ...v)
+                }
+                bus.addEventListener(event as any, cb)
+            }
+
+            if (isOmnibusRegistrator(bus)) {
+                bus.on(event, (...v) => omnibus.trigger(newEvent || event, ...v))
+            }
+
+            if (isOldschoolOnRegistrator(bus, event as string)) {
+                const prevCall = (bus as any)[`on${event as string}`]
+                (bus as any)[`on${event as string}`] = (...v) => {
+                    omnibus.trigger(newEvent || event, ...v)
+                    return prevCall(...v)
+                }
+                return
+            }
+            if (isCallbackRegistrator(bus)) {
+                bus(event as any, (...v) => omnibus.trigger(newEvent || event, ...v))
+                return
+            }
+        }
+
+        this.#registers.push(register)
+
+        return this as unknown as BusBuilder<D & Record<SecondIfUndefned<typeof newEvent, typeof event>, CallbackType<Ret, typeof event extends T ? typeof event : never>>, OmitKeys | SecondIfUndefned<typeof newEvent, typeof event>>
     }
 
     build() {
-        const bus = new Omnibus<FlatType<D>>(this.#transformers)
+        const bus = new Omnibus<FlatType<D>, OmitKeys>(this.#transformers)
+
+        // FIXME: probably needs to move this into omnibus itself to allow destructing.
+        this.#registers
+            .forEach(r => r(bus as Omnibus<any>))
 
         return bus
     }


### PR DESCRIPTION
### Version 0.1.3
- Added new `.from` method for `Omnibus.builder()` - you can now combine events from other buses (including native buses and other libraries!)