### PR TITLE
Add repository and homepage

### DIFF
--- a/.changeset/thirty-bees-itch.md
+++ b/.changeset/thirty-bees-itch.md
@@ -1,0 +1,5 @@
+---
+"@hypersphere/omnibus": patch
+---
+
+adding homepage and repository information to package.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "license": "MIT",
+  "homepage": "https://hypersphere.blog/omnibus",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/h-sphere/omnibus"
+  },
   "devDependencies": {
     "@babel/plugin-proposal-explicit-resource-management": "^7.23.9",
     "@babel/preset-env": "^7.23.9",


### PR DESCRIPTION
Adding more information to package.json to surface them on npm website when searching for a package.

Solves #11.